### PR TITLE
shared/web/scripts: Remove unwanted blank & commented lines

### DIFF
--- a/shared/web/scripts/generateIdentity.sh
+++ b/shared/web/scripts/generateIdentity.sh
@@ -68,18 +68,14 @@ logMessage "Identity key generation (${identityBinary}:${BG_PID} completed (STEP
 if [[ ! -f $identityKey  ]]
 then
     logMessage "ERROR: Identity key not generated on run"
-    
-    
-    exit 3 
+    exit 3
 fi
 
 count=$(/bin/ls $identityDirPath | wc -l)
 if [[ $count -lt 4 ]]
 then
     logMessage "ERROR: All Identity files not generated on run"
-
-    #rm ${identityPidFile}
-    #exit 4
+    exit 4
 fi
 
 logMessage "Authorizing identity using identity key string (IdentityPidRef:${BG_PID}) "


### PR DESCRIPTION
Remove unwanted blank and commented lines in the generate identity bash
script.

Not sure, but, I think that something funny was when merged #3 #4 #5 and they were auto merged.